### PR TITLE
Have payments use only the payment address, and keep previous rounds

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -588,7 +588,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
                             return;
                         case 'generate':
                             movePendingCommands.push(['smove', coin + ':blocksPending', coin + ':blocksConfirmed', r.serialized]);
-                            //roundsToDelete.push(coin + ':shares:round' + r.height);
+                            //roundsToDelete.push(coin + ':shares:round' + r.height); TODO, make this an option in poolconfig
                             return;
                     }
 

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -164,7 +164,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
             else {
                 var tBalance = 0;
                 for (var i = 0, len = result[0].response.length; i < len; i++) {
-                    tBalance = Number(tBalance + (result[0].response[i].amount * 100000000)).toFixed(0);
+                     tBalance = tBalance + Number((result[0].response[i].amount * magnitude));
                 }
                 logger.debug(logSystem, logComponent, addr + ' contains a balance of: ' + (tBalance / magnitude));
                 callback(null, tBalance);

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -509,7 +509,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
                         return;
                     }
 
-                    daemon.cmd('sendmany', [addressAccount || '', addressAmounts], function (result) {
+                    daemon.cmd('sendmany', [addressAccount, addressAmounts], function (result) {
                         //Check if payments failed because wallet doesn't have enough coins to pay for tx fees
                         if (result.error && result.error.code === -6) {
                             var higherPercent = withholdPercent + 0.01;
@@ -588,7 +588,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
                             return;
                         case 'generate':
                             movePendingCommands.push(['smove', coin + ':blocksPending', coin + ':blocksConfirmed', r.serialized]);
-                            roundsToDelete.push(coin + ':shares:round' + r.height);
+                            //roundsToDelete.push(coin + ':shares:round' + r.height);
                             return;
                     }
 


### PR DESCRIPTION
This commit is to prevent transactions where the pool uses the change addresses utxo's instead of the full block rewards like [here](https://classic.zcha.in/transactions/2bf4fff52c8be9042895009b7a9a7cae01f22c98e6a4ad8c07159a0928c9fc9c)